### PR TITLE
Support instantiation without properties

### DIFF
--- a/compile.js
+++ b/compile.js
@@ -21,7 +21,16 @@ function compileChildren (children) {
 function compile (item) {
     var type = item[0];
     var props = item[1];
-    var children = compileChildren(item.slice(2));
+    var children;
+
+    if (props != null && props.constructor === Object) {
+        children = item.slice(2)
+    } else {
+        props = {}
+        children = item.slice(1)
+    }
+
+    children = compileChildren(children);
 
     return React.createElement.apply(React, [type, props].concat(children));
 }

--- a/test/NoJsxSpec.js
+++ b/test/NoJsxSpec.js
@@ -34,17 +34,32 @@ var TestComponent = React.createClass({
     },
 });
 
-describe("no-jsx mixin", function () {
-    var result;
-    beforeEach(function () {
-        result = React.renderToStaticMarkup(React.createElement(TestComponent, {}));
-    });
+var TestBasicComponent = React.createClass({
+    mixins: [noJsxMixin],
 
+    renderTree: function () {
+        return ["div",
+            ["h1", "Foo"],
+            ["p", "Bar"],
+        ];
+    },
+})
+
+describe("no-jsx mixin", function () {
     it("should convert the items returned by renderTree() to React elements", function () {
+        var result = React.renderToStaticMarkup(React.createElement(TestComponent, {}));
         result.should.equal("<ul class=\"list\">" +
             "<li class=\"list__item\">foo <a href=\"#open\">open</a></li>" +
             "<li class=\"list__item\">5 <a href=\"#open\">open</a></li>" +
             "<li class=\"list__item\">meow <a href=\"#open\">open</a></li>" +
         "</ul>");
+    });
+
+    it("should convert basic definitions to React elements", function () {
+        var result = React.renderToStaticMarkup(React.createElement(TestBasicComponent, {}));
+        result.should.equal("<div>" +
+            "<h1>Foo</h1>" +
+            "<p>Bar</p>" +
+        "</div>");
     });
 });


### PR DESCRIPTION
Enable definitions without props (like reactionary).

``` js
renderTree: function () {
  return ["div",
    ["h1", "Foo"],
    ["p", "Bar"],
  ];
},
```
