### PR TITLE
Add an entry point to ease ES6 imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,6 @@
+"use strict";
+
+module.exports = {
+    compile: require("./compile"),
+    mixin: require("./mixin"),
+};

--- a/package.json
+++ b/package.json
@@ -18,8 +18,10 @@
   "bugs": {
     "url": "https://github.com/jussi-kalliokoski/react-no-jsx/issues"
   },
+  "main": "index.js",
   "files": [
     "compile.js",
+    "index.js",
     "mixin.js"
   ],
   "scripts": {

--- a/test/MainSpec.js
+++ b/test/MainSpec.js
@@ -1,0 +1,10 @@
+"use strict";
+
+describe("no-jsx", function () {
+    var noJsx = require("../index");
+
+    it("should export library functions", function () {
+        noJsx.should.have.property('compile');
+        noJsx.should.have.property('mixin');
+    });
+});


### PR DESCRIPTION
### Ease ES6 imports

Previously:

``` js
import * as compile from 'react-no-jsx/compile';
import * as mixin from 'react-no-jsx/mixin';
```

Now:

``` js
import {compile, mixin} from 'react-no-jsx';
```
